### PR TITLE
The latest version of PIL (Python Imaging Library) has deprecated the…

### DIFF
--- a/tools/common.py
+++ b/tools/common.py
@@ -50,7 +50,7 @@ def recreate_aligned_face(src_image, face_landmarks, output_size=256, transform_
     shrink = int(np.floor(qsize / output_size * 0.5))
     if shrink > 1:
         rsize = (int(np.rint(float(img.size[0]) / shrink)), int(np.rint(float(img.size[1]) / shrink)))
-        img = img.resize(rsize, Image.ANTIALIAS)
+        img = img.resize(rsize, Image.LANCZOS)
         quad /= shrink
         qsize /= shrink
 


### PR DESCRIPTION
… usage of the Image.ANTIALIAS constant. It has been replaced with Image.LANCZOS or Image.BICUBIC for image resizing operations. Image.LANCZOS is a high-quality resampling filter that prioritizes image quality when resizing.